### PR TITLE
fix duplicated entries on browser history when navigating with admin sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Fixed
+
+- Fixed duplicated browser history entries when navigating with admin sidebar.

--- a/react/components/Iframe.js
+++ b/react/components/Iframe.js
@@ -80,6 +80,7 @@ class Iframe extends Component {
         pathname.replace('/admin', isDeloreanAdmin ? '/admin/iframe' : '/admin/app')
       }${search}${hash}`
 
+      this.forceUpdate()
       this.iframe.contentWindow.location.replace(newPath.replace(/\/+/g, '/'))
     }
   }
@@ -151,6 +152,7 @@ class Iframe extends Component {
         src={src}
         ref={this.handleRef}
         onLoad={this.handleOnLoad}
+        key={src}
         data-hj-suppress
       />
     ) : null


### PR DESCRIPTION
Workspace with the linked solution: https://agostini--storecomponents.myvtex.com/admin/

## Description:  
The admin history was getting two entries when navigating from one page to another due to iframe's src url updating. To fix that we now reload the entire iframe for each navigation.


## Before: 
![history_before](https://user-images.githubusercontent.com/12215291/61391301-ca0c3500-a892-11e9-8dd3-fee61d45e539.gif)

## After
![history_after](https://user-images.githubusercontent.com/12215291/61391354-e5774000-a892-11e9-9fdc-00587a6125e0.gif)


