### PR TITLE
fix admin integrations navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed navigation on admin intregations config screen.
+
 ## [1.0.4] - 2019-07-19
 
 ### Fixed

--- a/react/components/Iframe.js
+++ b/react/components/Iframe.js
@@ -80,7 +80,6 @@ class Iframe extends Component {
         pathname.replace('/admin', isDeloreanAdmin ? '/admin/iframe' : '/admin/app')
       }${search}${hash}`
 
-      this.forceUpdate()
       this.iframe.contentWindow.location.replace(newPath.replace(/\/+/g, '/'))
     }
   }
@@ -152,7 +151,6 @@ class Iframe extends Component {
         src={src}
         ref={this.handleRef}
         onLoad={this.handleOnLoad}
-        key={src}
         data-hj-suppress
       />
     ) : null


### PR DESCRIPTION
Rollback on #3 
The #3 makes the whole iframe reload when the browser src is updated. This affects the SPA apps that manages its own routes and run inside admin. 