### PR TITLE
Remove legacy suggestions' routes

### DIFF
--- a/react/components/IframeUtils.js
+++ b/react/components/IframeUtils.js
@@ -2,13 +2,19 @@ import PropTypes from 'prop-types'
 import Cookies from 'js-cookie'
 import { intlShape } from 'react-intl'
 import axios from 'axios'
-let isPricingV2Active = window && window.localStorage && window.localStorage.getItem('routePriceSheetFromS3') || null
+let isPricingV2Active =
+  (window &&
+    window.localStorage &&
+    window.localStorage.getItem('routePriceSheetFromS3')) ||
+  null
 
 const getEnv = () => Cookies.get('vtex-commerce-env') || 'stable'
 
-const startLoading = () => window.postMessage({ action: { type: 'START_LOADING' } }, '*')
+const startLoading = () =>
+  window.postMessage({ action: { type: 'START_LOADING' } }, '*')
 
-const stopLoading = () => window.postMessage({ action: { type: 'STOP_LOADING' } }, '*')
+const stopLoading = () =>
+  window.postMessage({ action: { type: 'STOP_LOADING' } }, '*')
 
 const checkPricingVersion = async () => {
   // isPricingV2Active oneOf[true,false,null]
@@ -17,36 +23,33 @@ const checkPricingVersion = async () => {
   // null => request failed or localStorage is empty
   if (isPricingV2Active === null) {
     const res = await axios('/api/pricing/pvt/api-configuration')
-    isPricingV2Active = res.data && res.data.routePriceSheetFromS3 || null
+    isPricingV2Active = (res.data && res.data.routePriceSheetFromS3) || null
     localStorage.setItem('routePriceSheetFromS3', isPricingV2Active)
   }
 }
 
 const DELOREAN_REGISTRY = [
-  "billing",
-  "bridge",
-  "checkout",
-  "creditcontrol",
-  "fms",
-  "fms-picking",
-  "io-vtex-loader",
-  "license-manager",
-  "logistics",
-  "message-center",
-  "myaccount",
-  "payment-provider",
-  "pci-gateway",
-  "picking",
-  "portal",
-  "pricing",
-  "rnb",
-  "suggestions",
-  "suggestion",
-  "suggestions/catalog-mapping",
-  "suggestion/catalog-mapping",
-  "surveys",
-  "vtexid",
-  "vtable",
+  'billing',
+  'bridge',
+  'checkout',
+  'creditcontrol',
+  'fms',
+  'fms-picking',
+  'io-vtex-loader',
+  'license-manager',
+  'logistics',
+  'message-center',
+  'myaccount',
+  'payment-provider',
+  'pci-gateway',
+  'picking',
+  'portal',
+  'pricing',
+  'rnb',
+  'suggestion/config/catalog-mapping',
+  'surveys',
+  'vtexid',
+  'vtable',
 ]
 
 function componentDidMount() {
@@ -83,7 +86,7 @@ const propTypes = {
 
 const getLegacyHeaderTabs = pathName => {
   let tabs, title
-  switch(pathName.toLowerCase()) {
+  switch (pathName.toLowerCase()) {
     // IMPORT & EXPORT SECTION
     case '/admin/site/relatorio_skus.aspx':
     case '/admin/site/produtoexportacaoimportacaoespecificacaov2.aspx':
@@ -100,14 +103,20 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('Relatorio_Skus.aspx'),
         },
         {
-          label: 'appframe.navigation.catalog.importExport.productSpecification',
+          label:
+            'appframe.navigation.catalog.importExport.productSpecification',
           path: '/admin/Site/ProdutoExportacaoImportacaoEspecificacaoV2.aspx',
-          active: pathName.includes('ProdutoExportacaoImportacaoEspecificacaoV2.aspx'),
+          active: pathName.includes(
+            'ProdutoExportacaoImportacaoEspecificacaoV2.aspx'
+          ),
         },
         {
           label: 'appframe.navigation.catalog.importExport.skuSpecification',
-          path: '/admin/Site/ProdutoExportacaoImportacaoEspecificacaoSKUV2.aspx',
-          active: pathName.includes('ProdutoExportacaoImportacaoEspecificacaoSKUV2.aspx'),
+          path:
+            '/admin/Site/ProdutoExportacaoImportacaoEspecificacaoSKUV2.aspx',
+          active: pathName.includes(
+            'ProdutoExportacaoImportacaoEspecificacaoSKUV2.aspx'
+          ),
         },
         {
           label: 'appframe.navigation.catalog.importExport.importImages',
@@ -120,9 +129,12 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('ProdutoImagemExportacao.aspx'),
         },
         {
-          label: 'appframe.navigation.catalog.importExport.exportProductreviews',
+          label:
+            'appframe.navigation.catalog.importExport.exportProductreviews',
           path: '/admin/Site/ProdutoExportacaoImportacaoAvaliacao.aspx',
-          active: pathName.includes('ProdutoExportacaoImportacaoAvaliacao.aspx'),
+          active: pathName.includes(
+            'ProdutoExportacaoImportacaoAvaliacao.aspx'
+          ),
         },
       ]
       if (!isPricingV2Active) {
@@ -132,7 +144,7 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('SkuTabelaValor.aspx'),
         })
       }
-    break
+      break
     // SETTINGS SECTION
     case '/admin/site/configform.aspx':
     case '/admin/site/configseocontents.aspx':
@@ -167,7 +179,7 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('GeographicRegion.aspx'),
         },
       ]
-    break
+      break
     // REPORTS SECTION
     case '/admin/site/relatorioindexacao.aspx':
     case '/admin/site/relatorio_seguranca.aspx':
@@ -214,7 +226,7 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('LinksRelatorios.aspx'),
         },
       ]
-    break
+      break
     // ATTACHMENT SECTION
     case '/admin/site/anexo.aspx':
     case '/admin/site/skuservicotipo.aspx':
@@ -243,70 +255,70 @@ const getLegacyHeaderTabs = pathName => {
           active: pathName.includes('SkuVincularValorServico.aspx'),
         },
       ]
-    break
+      break
     case '/admin/site/giftlisttype.aspx':
       title = 'appframe.navigation.cms.settings.listTypes'
       tabs = []
-    break
+      break
     case '/admin/site/categories.aspx':
     case '/admin/site/categoriaform.aspx':
       title = 'appframe.navigation.catalog.categories'
       tabs = []
-    break
+      break
     case '/admin/site/marca.aspx':
     case '/admin/site/marcaform.aspx':
       title = 'appframe.navigation.catalog.brands'
       tabs = []
-    break
+      break
     case '/admin/site/store.aspx':
       title = 'appframe.navigation.channel'
       tabs = []
-    break
+      break
     case '/admin/site/vale.aspx':
       title = 'appframe.navigation.vouchers'
       tabs = []
-    break
+      break
     case '/admin/site/seller.aspx':
       title = 'appframe.navigation.sellerManagement.title'
       tabs = []
-    break
+      break
     case '/admin/site/skuseller.aspx':
       title = 'appframe.navigation.SKUbinding'
       tabs = []
-    break
+      break
     case '/admin/site/produto.aspx':
       title = 'appframe.navigation.catalog.products'
       tabs = []
-    break
+      break
     case '/admin/site/xml.aspx':
       title = 'appframe.navigation.catalog.xml'
       tabs = []
-    break
+      break
     case '/admin/site/skucondicaocomercial.aspx':
       title = 'appframe.navigation.catalog.commercialCondition'
       tabs = []
-    break
+      break
     case '/admin/site/fornecedor.aspx':
       title = 'appframe.navigation.catalog.suppliers'
       tabs = []
-    break
+      break
     case '/admin/site/skukit.aspx':
       title = 'appframe.navigation.catalog.sku-bundle'
       tabs = []
-    break
+      break
     case '/admin/site/skukitform.aspx':
       title = 'appframe.navigation.catalog.manage-sku-bundle'
       tabs = []
-    break
+      break
     case '/admin/a':
     case '/admin/a/':
       title = 'appframe.navigation.cms.pageHeader'
       tabs = []
-    break
+      break
     default:
       title = 'appframe.navigation.catalog.title'
       tabs = []
-    break
+      break
   }
   return { tabs, title }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -10,14 +10,6 @@
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-
 apollo-cache-inmemory@^1.1.7:
   version "1.2.10"
   resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.2.10.tgz#362d6c36cfd815a309b966f71e5d2b6c770c7989"
@@ -97,162 +89,13 @@ axios@^0.18.1:
     follow-redirects "1.5.10"
     is-buffer "^2.0.2"
 
-babel-code-frame@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
-
-babel-core@^6.26.0:
-  version "6.26.3"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-generator "^6.26.0"
-    babel-helpers "^6.24.1"
-    babel-messages "^6.23.0"
-    babel-register "^6.26.0"
-    babel-runtime "^6.26.0"
-    babel-template "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    convert-source-map "^1.5.1"
-    debug "^2.6.9"
-    json5 "^0.5.1"
-    lodash "^4.17.4"
-    minimatch "^3.0.4"
-    path-is-absolute "^1.0.1"
-    private "^0.1.8"
-    slash "^1.0.0"
-    source-map "^0.5.7"
-
-babel-generator@^6.26.0:
-  version "6.26.1"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.17.4"
-    source-map "^0.5.7"
-    trim-right "^1.0.1"
-
-babel-helpers@^6.24.1:
-  version "6.24.1"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.24.1.tgz#3471de9caec388e5c850e597e58a26ddf37602b2"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.24.1"
-
-babel-messages@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
-  dependencies:
-    babel-runtime "^6.22.0"
-
-babel-register@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
-  dependencies:
-    babel-core "^6.26.0"
-    babel-runtime "^6.26.0"
-    core-js "^2.5.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.17.4"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.15"
-
-babel-runtime@^6.22.0, babel-runtime@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
-  dependencies:
-    core-js "^2.4.0"
-    regenerator-runtime "^0.11.0"
-
-babel-template@^6.24.1, babel-template@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
-  dependencies:
-    babel-runtime "^6.26.0"
-    babel-traverse "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    lodash "^4.17.4"
-
-babel-traverse@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
-  dependencies:
-    babel-code-frame "^6.26.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.26.0"
-    babel-types "^6.26.0"
-    babylon "^6.18.0"
-    debug "^2.6.8"
-    globals "^9.18.0"
-    invariant "^2.2.2"
-    lodash "^4.17.4"
-
-babel-types@^6.26.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
-  dependencies:
-    babel-runtime "^6.26.0"
-    esutils "^2.0.2"
-    lodash "^4.17.4"
-    to-fast-properties "^1.0.3"
-
 babel@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
 
-babylon@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
-
-balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
 classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-
-convert-source-map@^1.5.1:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
-  dependencies:
-    safe-buffer "~5.1.1"
-
-core-js@^2.4.0, core-js@^2.5.0:
-  version "2.5.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
 
 debug@=3.1.0:
   version "3.1.0"
@@ -260,26 +103,6 @@ debug@=3.1.0:
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
-
-debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  dependencies:
-    ms "2.0.0"
-
-detect-indent@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
-  dependencies:
-    repeating "^2.0.0"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-esutils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
@@ -296,10 +119,6 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-globals@^9.18.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
-
 graphql-anywhere@^4.1.19:
   version "4.1.19"
   resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.19.tgz#5f6ca3b58218e5449f4798e3c6d942fcd2fef082"
@@ -310,22 +129,9 @@ graphql-tag@^2.4.2:
   version "2.9.2"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.9.2.tgz#2f60a5a981375f430bf1e6e95992427dc18af686"
 
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  dependencies:
-    ansi-regex "^2.0.0"
-
 hoist-non-react-statics@^2.5.5:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-
-home-or-tmp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
-  dependencies:
-    os-homedir "^1.0.0"
-    os-tmpdir "^1.0.1"
 
 intl-format-cache@^2.0.5:
   version "2.1.0"
@@ -347,7 +153,7 @@ intl-relativeformat@^2.1.0:
   dependencies:
     intl-messageformat "^2.0.0"
 
-invariant@^2.1.1, invariant@^2.2.2:
+invariant@^2.1.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -358,12 +164,6 @@ is-buffer@^2.0.2:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
-
 js-cookie@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.0.tgz#1b2c279a6eece380a12168b92485265b35b1effb"
@@ -372,71 +172,19 @@ js-cookie@^2.2.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
-
-jsesc@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-
-json5@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
-
-lodash@^4.17.4:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-
-mkdirp@^0.5.1:
-  version "0.5.1"
-  resolved "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
-  dependencies:
-    minimist "0.0.8"
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-
 object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-
-os-homedir@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
-
-os-tmpdir@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
-path-is-absolute@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-
-private@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
 prop-types@^15.5.10, prop-types@^15.6.2:
   version "15.6.2"
@@ -469,61 +217,15 @@ react-intl@^2.7.2:
     intl-relativeformat "^2.1.0"
     invariant "^2.1.1"
 
-regenerator-runtime@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
-
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
-
-safe-buffer@~5.1.1:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
-
 schedule@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/schedule/-/schedule-0.5.0.tgz#c128fffa0b402488b08b55ae74bb9df55cc29cc8"
   dependencies:
     object-assign "^4.1.1"
 
-slash@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
-
-source-map-support@^0.4.15:
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
-  dependencies:
-    source-map "^0.5.6"
-
-source-map@^0.5.6, source-map@^0.5.7:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  dependencies:
-    ansi-regex "^2.0.0"
-
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
 symbol-observable@^1.0.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-
-to-fast-properties@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-
-trim-right@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
 zen-observable-ts@^0.8.10:
   version "0.8.10"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove Delorean routes for Suggestions admin from this container.

#### What problem is this solving?
The legacy suggestions admin is being substituted by [this one](https://github.com/vtex/admin-suggestions/pull/36).

#### How should this be manually tested?
You can visit [this link](https://artur--lojadaju.myvtex.com/admin/suggestion/pending/) to see this code and the two below in action at the same time
https://github.com/vtex/admin-suggestions/pull/36
https://github.com/vtex/admin/pull/255

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/3827456/63525038-6699a680-c4d3-11e9-946b-200a0e9ca7e6.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.