### PR TITLE
Add customHeightGap prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+- `customHeightGap` prop to allow a defining the Iframe's height gap on a flexible fashion.
+
 ### Removed
+
+- Unused imports from the `Iframe.js` and `iframeUtils.js` files.
 - Rollback v1.0.9
 
 ## [1.0.9] - 2019-09-26

--- a/react/components/Iframe.js
+++ b/react/components/Iframe.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import { startsWith } from 'ramda'
-import { Spinner } from 'vtex.styleguide'
 import {
   stopLoading,
   getEnv,
@@ -138,6 +137,18 @@ class Iframe extends Component {
       return
     }
     const { loaded } = this.state
+    const { customHeightGap } = this.props
+    const style = {
+      width: "100%",
+      overflowY: "scroll",
+      // Admin V3's header height is 48px (3em), while the following version's
+      // header (Admin V4) is 56px (3.5em), and has a global alert that's displayed 
+      // on top of the header and has different heights depending on the
+      // viewport. The customHeightGap prop is used here to fit the iframe
+      // within the app in a flexible enough fashion, which allows to cover
+      // multiple use cases from within the apps that use this app.
+      height: `calc(100vh - ${customHeightGap ? customHeightGap : '3em' })`
+    }
 
     // if we update the iframe src, the iframe redirects to the src address and it automatically propagates this navigation to
     // the browser history (this is the expected behaviour https://trillworks.com/nick/2014/06/11/changing-the-src-attribute-of-an-iframe-modifies-the-history/)
@@ -149,8 +160,8 @@ class Iframe extends Component {
     const src = this.fixedSrc
     return loaded ? (
       <iframe
-        className="w-100 calc--height overflow-container"
         frameBorder="0"
+        style={style}
         src={src}
         ref={this.handleRef}
         onLoad={this.handleOnLoad}

--- a/react/components/IframeContainer.js
+++ b/react/components/IframeContainer.js
@@ -14,10 +14,11 @@ export default class IframeContainer extends Component {
     params: PropTypes.object,
     withoutLegacy: PropTypes.bool,
     children: PropTypes.node,
+    customHeightGap: PropTypes.string
   }
 
   render() {
-    const { params, withoutLegacy } = this.props
+    const { params, withoutLegacy, customHeightGap } = this.props
 
     const slug = params && params.slug || ''
 
@@ -31,13 +32,14 @@ export default class IframeContainer extends Component {
       // those are the old portal9 admins served by portal in vtexcommercestable
       return <IframeLegacy params={params} />
     } else if (isDeloreanAdmin(slug)) {
-      // this is covering "Legacy" admins versioned by Delorean
+      // This is covering "Legacy" admins versioned by Delorean
       // those were rendered by concierge, but now render delivers them as statics
       return <Iframe params={params} isDeloreanAdmin />
     } else {
-      // this covers the rest of cases, which are IO apps that are admins
+      // This covers the rest of cases, which are IO apps that are admins
       // with "/admin/app" routes and fallback to 404 slugs
-      return <Iframe params={params} />
+      // The customHeightGap is only used on the Admin V4 (see vtex/admin)
+      return <Iframe params={params} customHeightGap={customHeightGap} />
     }
   }
 }

--- a/react/components/IframeUtils.js
+++ b/react/components/IframeUtils.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import Cookies from 'js-cookie'
-import { intlShape } from 'react-intl'
 import axios from 'axios'
 let isPricingV2Active = window && window.localStorage && window.localStorage.getItem('routePriceSheetFromS3') || null
 


### PR DESCRIPTION
#### What does this PR do? \*
Adds the optional `customHeightGap` prop. It solves the following problem: currently, this app has a fixed height gap of 3em, which corresponds to the height of the Admin v3's header. The following Admin's version (admin v4) header has a 3.5em height and numerous cases where we need to change it's height gap dynamically, such as when the global alert is being displayed on top of the header, which adds another 64 ~ 88px to the header depending on the viewport width. The `customHeightGap` prop makes this app a little bit more flexible.

#### How to test it? \*
Head to [this workspace](https://marcelocardosodev6--ambienteqa.myvtex.com/admin) and take a look at the scrollbar BEFORE AND AFTER DISMISSING THE GLOBAL ALERT (_if you need to take a look again, delete the `dismissedGlobalAlert` item on your browser's localStorage and reload the page_). After you've done this, navigate to [this workspace](https://marcelocardosodev3--ambienteqa.myvtex.com/admin) and compare the scrollbar.

The first workspace controls the iframe's height gap and the second doesn't. So you'll see that the scrollbar matches the screen perfectly on the first workspace, and it doesn't by a few pixels on the second workspace.

#### Describe alternatives you've considered, if any. \*
I considered setting a fixed height gap for each of the admin's v4 cases, but that would make this app rigid, and full of props, and harder to customize on the future. Picture coming to this repo and adding another prop, or object on a prop, every time a new case comes up. That wouldn't be efficient.

I also considered making an entire style sheet available as a prop, but I'm not sure if that approach would be appropriate, as it would make possibly useless/unnecessary customization options available.

#### Related to  \*

For further information (screenshots) visit this PR:
https://github.com/vtex/admin/pull/312


> That should be a minor release