### PR TITLE
Cover flexible height gap case on legacy iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `customHeightGap` prop on the `IframeLegacy` component, to allow defining the Iframe's height gap on a flexible fashion.
+
+### Changed
+
+- Moved the Iframe's style logic to the `IframeUtils.js`, since that logic is now used in multiple components.
+
 ## [1.1.0] - 2020-11-10
 
 ### Added
 
-- `customHeightGap` prop to allow a defining the Iframe's height gap on a flexible fashion.
+- `customHeightGap` prop to allow defining the Iframe's height gap on a flexible fashion.
 
 ### Removed
 
@@ -19,7 +27,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rollback v1.0.9
 
 ## [1.0.9] - 2019-09-26
+
 ### Added
+
 - Prevent to show a black page while iframe is in loading.
 - Force reload when lost session.
 
@@ -49,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
- - Remove myuser old admin from the legacy admins whitelist
+- Remove myuser old admin from the legacy admins whitelist
 
 ## [1.0.2] - 2019-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 
-- Remove myuser old admin from the legacy admins whitelist
+ - Remove myuser old admin from the legacy admins whitelist
 
 ## [1.0.2] - 2019-07-17
 

--- a/react/components/Iframe.js
+++ b/react/components/Iframe.js
@@ -9,6 +9,7 @@ import {
   handleRef,
   contextTypes,
   propTypes,
+  iframeStyle
 } from './IframeUtils'
 
 class Iframe extends Component {
@@ -138,17 +139,6 @@ class Iframe extends Component {
     }
     const { loaded } = this.state
     const { customHeightGap } = this.props
-    const style = {
-      width: "100%",
-      overflowY: "scroll",
-      // Admin V3's header height is 48px (3em), while the following version's
-      // header (Admin V4) is 56px (3.5em), and has a global alert that's displayed 
-      // on top of the header and has different heights depending on the
-      // viewport. The customHeightGap prop is used here to fit the iframe
-      // within the app in a flexible enough fashion, which allows to cover
-      // multiple use cases from within the apps that use this app.
-      height: `calc(100vh - ${customHeightGap ? customHeightGap : '3em' })`
-    }
 
     // if we update the iframe src, the iframe redirects to the src address and it automatically propagates this navigation to
     // the browser history (this is the expected behaviour https://trillworks.com/nick/2014/06/11/changing-the-src-attribute-of-an-iframe-modifies-the-history/)
@@ -161,7 +151,7 @@ class Iframe extends Component {
     return loaded ? (
       <iframe
         frameBorder="0"
-        style={style}
+        style={iframeStyle({ customHeightGap })}
         src={src}
         ref={this.handleRef}
         onLoad={this.handleOnLoad}

--- a/react/components/IframeContainer.js
+++ b/react/components/IframeContainer.js
@@ -24,13 +24,13 @@ export default class IframeContainer extends Component {
 
     if (withoutLegacy) {
       // Cover just IO apps, ignore legacy apps.
-      return <Iframe params={params} />
+      return <Iframe params={params} customHeightGap={customHeightGap} />
     }
 
     if (isLegacy(slug)) {
       // IframeLegacy and isLegacy are covering Catalog and Legacy CMS admins
       // those are the old portal9 admins served by portal in vtexcommercestable
-      return <IframeLegacy params={params} />
+      return <IframeLegacy params={params} customHeightGap={customHeightGap} />
     } else if (isDeloreanAdmin(slug)) {
       // This is covering "Legacy" admins versioned by Delorean
       // those were rendered by concierge, but now render delivers them as statics

--- a/react/components/IframeLegacy.js
+++ b/react/components/IframeLegacy.js
@@ -1,4 +1,4 @@
-import { stopLoading, getEnv, componentDidMount, componentWillUnmount, updateChildLocale, handleRef, contextTypes, propTypes, checkPricingVersion } from './IframeUtils'
+import { stopLoading, getEnv, componentDidMount, componentWillUnmount, updateChildLocale, handleRef, contextTypes, propTypes, checkPricingVersion, iframeStyle } from './IframeUtils'
 import LegacyHeader from './LegacyHeader'
 import { injectIntl } from 'react-intl'
 import React, { Component } from 'react'
@@ -92,8 +92,8 @@ class IframeLegacy extends Component {
   }
 
   render() {
-    const { account, navigate } = this.context
-    const { intl, params: { slug = '' } } = this.props
+    const { account } = this.context
+    const { params: { slug = '' }, customHeightGap } = this.props
     const { loaded, iframeQuery } = this.state
     const hash = loaded ? window.location.hash : ''
     const search = loaded ? window.location.search || '' : ''
@@ -109,7 +109,7 @@ class IframeLegacy extends Component {
     const src = `${getLegacyBaseURL(account)}${slug}${patchedSearch}${hash}`
 
     return loaded ? (
-      <div className="w-100 calc--height overflow-container">
+      <div style={iframeStyle({ customHeightGap })}>
         <LegacyHeader search={iframeQuery} slug={slug} />
         <iframe
           style={{ height: 700 }}

--- a/react/components/IframeUtils.js
+++ b/react/components/IframeUtils.js
@@ -310,6 +310,19 @@ const getLegacyHeaderTabs = pathName => {
   return { tabs, title }
 }
 
+const iframeStyle = ({ customHeightGap }) => ({
+  width: '100%',
+  overflowY: 'scroll',
+  // Admin V3's header height is 48px (3em), while the following version's
+  // header (Admin V4) is 56px (3.5em), and has a global alert that's displayed
+  // on top of the header and has different heights depending on the
+  // viewport. The customHeightGap prop is used here to fit the iframe
+  // within the app in a flexible enough fashion, which allows to cover
+  // multiple use cases from within the apps that use this app.
+  height: `calc(100vh - ${customHeightGap ? customHeightGap : '3em'})`,
+})
+
+
 export {
   stopLoading,
   getEnv,
@@ -322,4 +335,5 @@ export {
   getLegacyHeaderTabs,
   checkPricingVersion,
   DELOREAN_REGISTRY,
+  iframeStyle
 }


### PR DESCRIPTION
#### What does this PR do? \*
Passes the `customHeightGap` prop to the legacy iframe. Currently, legacy apps within the iframe are not benefited with the https://github.com/vtex/admin-iframe-container/pull/12, as that only targeted non-legacy apps.

#### How to test it? \*
Head to [this workspace](https://marcelocardosodev2--ambienteqa.myvtex.com/admin/Site/Produto.aspx) and take a look at the scrollbar BEFORE AND AFTER DISMISSING THE GLOBAL ALERT (_if you need to take a look again, delete the `dismissedGlobalAlert` item on your browser's localStorage and reload the page_). After you've done this, navigate to [this workspace](https://newadmin--storecomponents.myvtex.com/admin/Site/Produto.aspx) and compare the scrollbar.

As the latter has the sidebar's second level already implemented, I suggest you use that to navigate across the catalog apps (which are all legacy) and simply paste the URL on the former workspace to compare both workspaces across multiple legacy apps.

In order to test retrocompatibility, navigate to [this workspace](https://marcelocardosodev6--ambienteqa.myvtex.com/admin/Site/Produto.aspx)

#### Related to  \*

For further information (screenshots) visit this PR:
https://github.com/vtex/admin/pull/324

> That should be a minor release